### PR TITLE
dot-unlinking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea/
 target/
+*.dots.toml
+dots.toml
+tests/
+tests.*/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,56 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +63,52 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "clap"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "dirs"
@@ -32,13 +128,14 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "dots"
 version = "1.0.0"
 dependencies = [
+ "clap",
  "dirs",
  "serde",
  "toml",
@@ -68,6 +165,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +179,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "libc"
@@ -92,6 +201,12 @@ dependencies = [
  "bitflags",
  "libc",
 ]
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "option-ext"
@@ -156,6 +271,12 @@ checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -234,6 +355,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,11 +368,36 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -254,15 +406,21 @@ version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -272,9 +430,21 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -284,9 +454,21 @@ checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -296,15 +478,33 @@ checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dots"
 description = "System-agnostic dotfile-deployer "
-version = "1.0.0"
+version = "2.0.0"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
+clap = { version = "4.5.41", features = ["derive"] }
 dirs = "6.0.0"
 serde = { version = "1.0.219", features = ["derive"] }
 toml = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "dots"
+description = "System-agnostic dotfile-deployer "
 version = "1.0.0"
 edition = "2024"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,8 +2,9 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
+#[clap(author = "Max Bossing", version, about = "System-agnostic dotfile deployer", long_about = None)]
 pub struct Cli {
-    #[arg(default_value = "dots.toml")]
+    #[arg(short, long, default_value = "dots.toml")]
     pub config: Option<PathBuf>,
     
     #[command(subcommand)]
@@ -12,6 +13,8 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum CliCommand {
+    #[clap(about = "Deploys a dots set")]
     Deploy,
+    #[clap(about = "Unlinks (tries to remove) a dots deployment")]
     Unlink
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,5 +13,5 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum CliCommand {
     Deploy,
-    Undeploy
+    Unlink
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+pub struct Cli {
+    #[arg(default_value = "dots.toml")]
+    pub config: Option<PathBuf>,
+    
+    #[command(subcommand)]
+    pub command: CliCommand 
+}
+
+#[derive(Subcommand)]
+pub enum CliCommand {
+    Deploy,
+    Undeploy
+}

--- a/src/dots.rs
+++ b/src/dots.rs
@@ -1,0 +1,48 @@
+use std::fs::{remove_file, symlink_metadata};
+use std::os::unix::fs::symlink;
+use std::path::PathBuf;
+use dirs::home_dir;
+use crate::config::Dot;
+
+pub fn deploy_dots(dots: Vec<Dot>, dots_dir: PathBuf) {
+    let prepended_dots = dots.iter().map(|m|
+        Dot {
+            source: dots_dir.join(&m.source),
+            destination: prepend_user_dir(&m.destination)
+        }
+    );
+
+    for dot in prepended_dots {
+        println!("linking from {} to {}", dot.source.display(), dot.destination.display());
+        let _ = symlink(&dot.source, &dot.destination).map_err(|err|
+            eprintln!("failed to symlink: {}", err.to_string())
+        );
+    }
+}
+
+pub fn unlink_dots(dots: Vec<Dot>, dots_dir: PathBuf) {
+    let prepended_dots = dots.iter().map(|m|
+        Dot {
+            source: dots_dir.join(&m.source),
+            destination: prepend_user_dir(&m.destination)
+        }
+    );
+
+    for dot in prepended_dots {
+        println!("unlinking  {}", dot.destination.display());
+        let metadata = symlink_metadata(dot.destination.clone());
+        if metadata.is_err() {
+            eprintln!("failed to query metadata for {}: {}", dot.destination.display(), metadata.err().unwrap());
+            continue
+        }
+        if metadata.ok().unwrap().is_symlink() {
+            let _ = remove_file(dot.destination).map_err(|err|
+                eprintln!("failed to remove symlink: {}", err)
+            );
+        }
+    }
+}
+
+fn prepend_user_dir(path: &PathBuf) -> PathBuf {
+    home_dir().unwrap().join(path)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,11 @@ use clap::Parser;
 use dirs::{home_dir};
 use crate::cli::{Cli, CliCommand};
 use crate::config::{Config, ConfigLoadError, Dot};
+use crate::dots::{deploy_dots, unlink_dots};
 
 mod config;
 mod cli;
+mod dots;
 
 fn main() {
     let cli = Cli::parse();
@@ -31,47 +33,4 @@ fn main() {
         CliCommand::Deploy => deploy_dots(config.dots, config.dots_dir),
         CliCommand::Undeploy => {}
     }
-}
-
-fn deploy_dots(dots: Vec<Dot>, dots_dir: PathBuf) {
-    let prepended_dots = dots.iter().map(|m|
-        Dot {
-            source: dots_dir.join(&m.source),
-            destination: prepend_user_dir(&m.destination)
-        }
-    );
-    
-    for dot in prepended_dots {
-        println!("linking from {} to {}", dot.source.display(), dot.destination.display());
-        let _ = symlink(&dot.source, &dot.destination).map_err(|err|
-            eprintln!("failed to symlink: {}", err.to_string())
-        );
-    }
-}
-
-fn undeploy_dots(dots: Vec<Dot>, dots_dir: PathBuf) {
-    let prepended_dots = dots.iter().map(|m|
-        Dot {
-            source: dots_dir.join(&m.source),
-            destination: prepend_user_dir(&m.destination)
-        }
-    );
-
-    for dot in prepended_dots {
-        println!("unlinking  {}", dot.destination.display());
-        let metadata = symlink_metadata(dot.destination.clone());
-        if metadata.is_err() {
-            eprintln!("failed to query metadata for {}: {}", dot.destination.display(), metadata.err().unwrap());
-            continue
-        }
-        if metadata.ok().unwrap().is_symlink() {
-            let _ = remove_file(dot.destination).map_err(|err| 
-                eprintln!("failed to remove symlink: {}", err)
-            );
-        }
-    }
-}
-
-fn prepend_user_dir(path: &PathBuf) -> PathBuf {
-    home_dir().unwrap().join(path)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,7 @@
-use std::env;
-use std::fs::{remove_file, symlink_metadata};
-use std::os::unix::fs::symlink;
-use std::path::PathBuf;
 use std::process::exit;
 use clap::Parser;
-use dirs::{home_dir};
 use crate::cli::{Cli, CliCommand};
-use crate::config::{Config, ConfigLoadError, Dot};
+use crate::config::{Config, ConfigLoadError};
 use crate::dots::{deploy_dots, unlink_dots};
 
 mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,6 @@ fn main() {
     
     match cli.command {
         CliCommand::Deploy => deploy_dots(config.dots, config.dots_dir),
-        CliCommand::Undeploy => {}
+        CliCommand::Unlink => unlink_dots(config.dots, config.dots_dir),
     }
 }


### PR DESCRIPTION
Adds the possibility to unlink dots given a `dots.toml` via a subcommand. This breaks the current UX, and introduces a new CLI system ([clap](https://docs.rs/clap)) to simplify the arg logic and allow for simpler future changes in a backwards-compatible manner, although I intend to keep any more changes now as minimal as possible.

!BREAKING CHANGE - Version bump to 2.0.0